### PR TITLE
Handle missing Firebase Admin credentials during build

### DIFF
--- a/src/api/auth/session/route.ts
+++ b/src/api/auth/session/route.ts
@@ -1,6 +1,6 @@
 
 import { getAuth } from "firebase-admin/auth";
-import { getAdminApp } from "@/lib/firebase/admin-sdk";
+import { FirebaseAdminInitializationError, getAdminApp } from "@/lib/firebase/admin-sdk";
 import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
 
@@ -22,6 +22,12 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ status: "success" });
     } catch (error) {
         console.error("Error creating session cookie:", error);
+        if (error instanceof FirebaseAdminInitializationError) {
+            return NextResponse.json(
+                { status: "error", message: "Firebase Admin SDK is not configured." },
+                { status: 500 }
+            );
+        }
         return NextResponse.json({ status: "error" }, { status: 401 });
     }
 }

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,6 +1,6 @@
 
 import { getAuth } from "firebase-admin/auth";
-import { getAdminApp } from "@/lib/firebase/admin-sdk";
+import { FirebaseAdminInitializationError, getAdminApp } from "@/lib/firebase/admin-sdk";
 import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
 
@@ -22,6 +22,12 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ status: "success" });
     } catch (error) {
         console.error("Error creating session cookie:", error);
+        if (error instanceof FirebaseAdminInitializationError) {
+            return NextResponse.json(
+                { status: "error", message: "Firebase Admin SDK is not configured." },
+                { status: 500 }
+            );
+        }
         return NextResponse.json({ status: "error" }, { status: 401 });
     }
 }

--- a/src/lib/firebase/admin-sdk.ts
+++ b/src/lib/firebase/admin-sdk.ts
@@ -1,11 +1,12 @@
 
 import { initializeApp, getApps, App, cert } from 'firebase-admin/app';
 
-const serviceAccount = {
-  projectId: process.env.FIREBASE_PROJECT_ID,
-  privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
-  clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-};
+export class FirebaseAdminInitializationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FirebaseAdminInitializationError';
+  }
+}
 
 /**
  * Initializes and/or returns the Firebase Admin App instance.
@@ -15,18 +16,24 @@ const serviceAccount = {
 export function getAdminApp(): App {
   const appName = 'firebase-admin-app';
   const existingApp = getApps().find(app => app.name === appName);
-  
+
   if (existingApp) {
     return existingApp;
   }
-  
+
+  const serviceAccount = {
+    projectId: process.env.FIREBASE_PROJECT_ID,
+    privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+    clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+  };
+
   if (
     !serviceAccount.projectId ||
     !serviceAccount.privateKey ||
     !serviceAccount.clientEmail
   ) {
-    throw new Error(
-      "Firebase service account credentials are not set in environment variables. Please check your .env file."
+    throw new FirebaseAdminInitializationError(
+      'Firebase service account credentials are not set in environment variables. Please check your .env file.'
     );
   }
 

--- a/src/lib/user.actions.ts
+++ b/src/lib/user.actions.ts
@@ -2,7 +2,7 @@
 'use server';
 
 import { getAuth } from "firebase-admin/auth";
-import { getAdminApp } from "@/lib/firebase/admin-sdk";
+import { FirebaseAdminInitializationError, getAdminApp } from "@/lib/firebase/admin-sdk";
 
 interface CreateUserParams {
     email: string;
@@ -39,14 +39,16 @@ export async function createUser(data: CreateUserParams): Promise<{ success: boo
 
     } catch (error: any) {
         console.error('Error creating new user:', error);
-        
+
         let errorMessage = 'An unknown error occurred while creating the user.';
-        if (error.code === 'auth/email-already-exists') {
+        if (error instanceof FirebaseAdminInitializationError) {
+            errorMessage = 'Firebase Admin SDK is not configured. Please set the required environment variables.';
+        } else if (error.code === 'auth/email-already-exists') {
             errorMessage = 'The email address is already in use by another account.';
         } else if (error.code === 'auth/invalid-password') {
             errorMessage = 'The password must be a string with at least 6 characters.';
         }
-        
+
         return { success: false, error: errorMessage };
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated FirebaseAdminInitializationError and guard admin app initialization against missing credentials
- make Firestore and Auth accessors lazy and fail-safe across server actions so requests fall back gracefully when Firebase is unavailable
- update session API routes to return clearer errors when admin credentials are not configured

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dde80c00248327930949a6b71cb45a