### PR TITLE
Improve middleware resilience and Firebase logging

### DIFF
--- a/src/api/auth/session/route.ts
+++ b/src/api/auth/session/route.ts
@@ -21,10 +21,13 @@ export async function POST(request: NextRequest) {
         });
         return NextResponse.json({ status: "success" });
     } catch (error) {
-        console.error("Error creating session cookie:", error);
+        console.error("Error creating session cookie", error);
         if (error instanceof FirebaseAdminInitializationError) {
+            console.error("Firebase Admin initialization failed while creating session cookie", {
+                message: error.message,
+            });
             return NextResponse.json(
-                { status: "error", message: "Firebase Admin SDK is not configured." },
+                { status: "error", message: error.message },
                 { status: 500 }
             );
         }

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -21,10 +21,13 @@ export async function POST(request: NextRequest) {
         });
         return NextResponse.json({ status: "success" });
     } catch (error) {
-        console.error("Error creating session cookie:", error);
+        console.error("Error creating session cookie", error);
         if (error instanceof FirebaseAdminInitializationError) {
+            console.error("Firebase Admin initialization failed while creating session cookie", {
+                message: error.message,
+            });
             return NextResponse.json(
-                { status: "error", message: "Firebase Admin SDK is not configured." },
+                { status: "error", message: error.message },
                 { status: 500 }
             );
         }

--- a/src/lib/firebase/admin-sdk.ts
+++ b/src/lib/firebase/admin-sdk.ts
@@ -27,14 +27,18 @@ export function getAdminApp(): App {
     clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
   };
 
-  if (
-    !serviceAccount.projectId ||
-    !serviceAccount.privateKey ||
-    !serviceAccount.clientEmail
-  ) {
-    throw new FirebaseAdminInitializationError(
-      'Firebase service account credentials are not set in environment variables. Please check your .env file.'
-    );
+  const missingVariables = Object.entries({
+    FIREBASE_PROJECT_ID: serviceAccount.projectId,
+    FIREBASE_PRIVATE_KEY: serviceAccount.privateKey,
+    FIREBASE_CLIENT_EMAIL: serviceAccount.clientEmail,
+  })
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missingVariables.length > 0) {
+    const message = `Missing Firebase Admin environment variables: ${missingVariables.join(', ')}`;
+    console.error(message);
+    throw new FirebaseAdminInitializationError(message);
   }
 
   return initializeApp({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 
 import { createI18nMiddleware } from 'next-international/middleware';
+import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
  
 const I18nMiddleware = createI18nMiddleware({
@@ -9,7 +10,16 @@ const I18nMiddleware = createI18nMiddleware({
 });
  
 export function middleware(request: NextRequest) {
-  return I18nMiddleware(request);
+  try {
+    return I18nMiddleware(request);
+  } catch (error) {
+    console.error('Edge middleware failed', {
+      error,
+      url: request.nextUrl.href,
+    });
+
+    return NextResponse.rewrite(new URL('/500', request.url));
+  }
 }
  
 export const config = {


### PR DESCRIPTION
## Summary
- wrap the Edge internationalization middleware with error handling that logs failures and rewrites to a fallback page
- report missing Firebase Admin environment variables explicitly during initialization
- enhance session API logging to surface Firebase configuration issues when creating cookies

## Testing
- ⚠️ `npm run lint` (fails: command requires interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e5ce0059b08327ae2dd75385c592d2